### PR TITLE
Add whole group push simulation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -469,7 +469,7 @@ valid-metaclass-classmethod-first-arg=cls
 max-args=5
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=8
 
 # Maximum number of boolean expressions in an if statement.
 max-bool-expr=5

--- a/blaze/action/action.py
+++ b/blaze/action/action.py
@@ -5,7 +5,7 @@ take when exploring push policies
 
 from typing import Optional
 
-from blaze.config.environment import PushGroup, Resource
+from blaze.config.environment import Resource
 
 class Action():
   """

--- a/blaze/action/action.py
+++ b/blaze/action/action.py
@@ -3,7 +3,7 @@ This module contains the main class representing an action that an agent can
 take when exploring push policies
 """
 
-from typing import List
+from typing import Optional
 
 from blaze.config.environment import PushGroup, Resource
 
@@ -13,22 +13,10 @@ class Action():
   a pair of resources (source, push) which describe the resource that should be pushed
   upon a request for a given resource
   """
-  def __init__(self, action_id: int = 0, g: int = 0, s: int = 0, p: int = 0, push_groups: List[PushGroup] = None):
+  def __init__(self, action_id: int = 0, source: Optional[Resource] = None, push: Optional[Resource] = None):
     self.action_id = action_id
-    self.g = g
-    self.s = s
-    self.p = p
-    self.push_groups = push_groups or []
-
-  @property
-  def source(self) -> Resource:
-    """ Return the source resource for this action """
-    return self.push_groups[self.g].resources[self.s]
-
-  @property
-  def push(self) -> Resource:
-    """ Return the push resource for this action """
-    return self.push_groups[self.g].resources[self.p]
+    self.source = source
+    self.push = push
 
   @property
   def is_noop(self):

--- a/blaze/action/action_space.py
+++ b/blaze/action/action_space.py
@@ -27,13 +27,13 @@ class ActionSpace(gym.spaces.Discrete):
     self.push_resources: List[Resource] = []
     self.action_id_map: Dict[Tuple[int, int, int], int] = {}
     self.actions: List[Action] = [Action()]
-    for g, group in enumerate(push_groups):
-      for s, source in enumerate(group.resources):
-        if s != 0:
+    for group in push_groups:
+      for source in group.resources:
+        if source.source_id != 0:
           self.push_resources.append(source)
-        for p in range(s + 1, len(group.resources)):
-          self.action_id_map[(g, s, p)] = len(self.actions)
-          self.actions.append(Action(len(self.actions), g, s, p, push_groups))
+        for push in group.resources[source.source_id+1:]:
+          self.action_id_map[(source.group_id, source.source_id, push.source_id)] = len(self.actions)
+          self.actions.append(Action(len(self.actions), source, push))
     self.push_resources.sort(key=lambda r: r.order)
     super(ActionSpace, self).__init__(len(self.actions))
 

--- a/blaze/command/preprocess.py
+++ b/blaze/command/preprocess.py
@@ -12,6 +12,8 @@ from . import command
 @command.argument('website', help='The URL of the website to prepare for training')
 @command.argument('--depth', help='The recursive depth of URLs to process for the given page', default=0, type=int)
 @command.argument('--output', help='The location to save the prepared manifest', required=True)
+@command.argument('--train_domain_suffix', help='The suffix of domain names to enable training for. By default this '
+                                                'will be the domain of the given URL')
 @command.argument('--record_dir', help='The directory to save the recorded webpage', required=True)
 @command.command
 def preprocess(args):
@@ -20,7 +22,8 @@ def preprocess(args):
   and finds the stable set of page dependencies. The page load is recorded and stored and a
   training manifest is outputted.
   """
-  log.info('preprocessing website', website=args.website, depth=args.depth)
+  domain = args.train_domain_suffix or Url.parse(args.website).domain
+  log.info('preprocessing website', website=args.website, depth=args.depth, train_domain="*.{}".format(domain))
 
   config = get_config()
   log.debug('using configuration', **config._asdict())
@@ -32,7 +35,7 @@ def preprocess(args):
   res_list = find_url_stable_set(args.website, config)
 
   log.info('found total dependencies', total=len(res_list))
-  push_groups = resource_list_to_push_groups(res_list)
+  push_groups = resource_list_to_push_groups(res_list, train_domain_suffix=domain)
 
   log.info('generating configuration...')
   env_config = EnvironmentConfig(

--- a/blaze/config/config.py
+++ b/blaze/config/config.py
@@ -23,13 +23,13 @@ class Config(NamedTuple):
   pwmetrics_bin: str
   nghttpx_bin: str
   chrome_bin: str
-  train_config: Optional[EnvironmentConfig] = None
+  env_config: Optional[EnvironmentConfig] = None
 
   def items(self):
     """ Return the dictionary items() method for this object """
     return self._asdict().items() # pylint: disable=no-member
 
-def get_config(train_config: Optional[EnvironmentConfig] = None) -> Config:
+def get_config(env_config: Optional[EnvironmentConfig] = None) -> Config:
   """
   get_config returns the runtime configuration, taking values from environment variables
   when available to override the defaults
@@ -40,5 +40,5 @@ def get_config(train_config: Optional[EnvironmentConfig] = None) -> Config:
     pwmetrics_bin=os.environ.get('PWMETRICS_BIN', DEFAULT_PWMETRICS_BIN),
     nghttpx_bin=os.environ.get('NGHTTPX_BIN', DEFAULT_NGHTTPX_BIN),
     chrome_bin=os.environ.get('CHROME_BIN', DEFAULT_CHROME_BIN),
-    train_config=train_config,
+    env_config=env_config,
   )

--- a/blaze/config/environment.py
+++ b/blaze/config/environment.py
@@ -36,6 +36,7 @@ class PushGroup(NamedTuple):
   """ PushGroup collects a group of resources for the same domain """
   group_name: str
   resources: List[Resource]
+  trainable: bool = True
 
 class EnvironmentConfig(NamedTuple):
   """ EnvironmentConfig is the main configuration used in setting up the training environment """

--- a/blaze/environment/environment.py
+++ b/blaze/environment/environment.py
@@ -30,7 +30,7 @@ class Environment(gym.Env):
       'initialized trainable push groups',
       groups=[group.group_name for group in self.trainable_push_groups],
     )
-    
+
     self.observation_space = get_observation_space()
     self.analyzer = Analyzer(self.config)
     self.initialize_environment(client_environment)

--- a/blaze/environment/environment.py
+++ b/blaze/environment/environment.py
@@ -1,4 +1,6 @@
 """ Defines the environment that the training of the agent occurs in """
+import random
+
 import gym
 
 from blaze.config import client, Config
@@ -21,38 +23,38 @@ class Environment(gym.Env):
     assert isinstance(config, (Config, dict))
     config = config if isinstance(config, Config) else Config(**config)
 
+    self.config = config
+    self.env_config = config.env_config
+    self.observation_space = get_observation_space()
+    self.analyzer = Analyzer(self.config)
+    self.initialize_environment(client_environment)
+
+  def reset(self):
+    self.initialize_environment()
+    return self.observation
+
+  def initialize_environment(self, client_environment=client.get_random_client_environment()):
+    """ Initialize the environment """
     log.info(
       'initializing environment',
       network_type=client_environment.network_type,
       network_speed=client_environment.network_speed,
       device_speed=client_environment.device_speed,
     )
-
-    self.config = config
-    self.train_config = config.train_config
     self.client_environment = client_environment
-
-    self.action_space = ActionSpace(self.train_config.push_groups)
-    self.observation_space = get_observation_space()
-
-    self.policy = Policy(self.action_space)
-    self.analyzer = Analyzer(self.config, self.client_environment)
-
-  def reset(self):
-    self.action_space = ActionSpace(self.train_config.push_groups)
-    self.policy = Policy(self.action_space)
-
-    self.client_environment = client.get_random_client_environment()
     self.analyzer.reset(self.client_environment)
 
-    log.info(
-      'initializing environment',
-      network_type=self.client_environment.network_type,
-      network_speed=self.client_environment.network_speed,
-      device_speed=self.client_environment.device_speed,
-    )
+    trainable_push_groups = [group for group in self.env_config.push_groups if group.trainable]
+    self.action_space = ActionSpace(trainable_push_groups)
+    self.policy = Policy(self.action_space)
 
-    return self.observation
+    # choose a random non-trainable push group to simulate as if it's already pushed
+    candidate_push_groups = [group for group in self.env_config.push_groups
+                             if len(group.resources) > 2 and not group.trainable]
+    if candidate_push_groups:
+      default_group = random.choice(candidate_push_groups)
+      for push in default_group.resources[1:]:
+        self.policy.add_default_action(default_group.resources[0], push)
 
   def step(self, action):
     decoded_action = self.action_space.decode_action_id(action)
@@ -77,4 +79,4 @@ class Environment(gym.Env):
   @property
   def observation(self):
     """ Returns an observation for the current state of the environment """
-    return get_observation(self.client_environment, self.train_config.push_groups, self.policy)
+    return get_observation(self.client_environment, self.env_config.push_groups, self.policy)

--- a/blaze/environment/observation.py
+++ b/blaze/environment/observation.py
@@ -58,7 +58,7 @@ def get_observation(client_environment: ClientEnvironment, push_groups: List[Pus
       res_size_kb = res.size//1000
       encoded_resources[str(res.order)] = np.array([1, res_type, res_size_kb, 0])
 
-  for (source, push) in policy:
+  for (source, push) in policy.observable:
     for push_res in push:
       # note that the pushed-from field is offset by 1, so that 0 indictates not pushed
       encoded_resources[str(push_res.order)][3] = source.order + 1

--- a/blaze/environment/observation.py
+++ b/blaze/environment/observation.py
@@ -28,8 +28,8 @@ def get_observation_space():
     len(ResourceType),
     # the size in kilobytes
     MAX_KBYTES,
-    # the resource that pushed this one
-    MAX_RESOURCES
+    # the resource that pushed this one, offset by 1 so that 0 indicates not pushed
+    MAX_RESOURCES + 1
   ])
   return gym.spaces.Dict({
     'client': gym.spaces.Dict({
@@ -60,7 +60,8 @@ def get_observation(client_environment: ClientEnvironment, push_groups: List[Pus
 
   for (source, push) in policy:
     for push_res in push:
-      encoded_resources[str(push_res.order)][3] = source.order
+      # note that the pushed-from field is offset by 1, so that 0 indictates not pushed
+      encoded_resources[str(push_res.order)][3] = source.order + 1
 
   return {
     'client': {

--- a/blaze/evaluator/analyzer.py
+++ b/blaze/evaluator/analyzer.py
@@ -25,7 +25,7 @@ class Analyzer():
   a better speed index than the previous policy, or a worse speed index than the
   previous policy
   """
-  def __init__(self, config: Config, client_environment: client.ClientEnvironment):
+  def __init__(self, config: Config, client_environment: Optional[client.ClientEnvironment] = None):
     self.config = config
     self.client_environment = client_environment
     self.min_speed_index = MIN_SPEED_INDEX

--- a/blaze/evaluator/lighthouse.py
+++ b/blaze/evaluator/lighthouse.py
@@ -49,7 +49,7 @@ def get_metrics(config: Config, mahimahi_config: MahiMahiConfig) -> Result:
 
     with open(config_file, 'w') as f:
       f.write(CONFIG_TEMPLATE.format(
-        url=config.train_config.request_url,
+        url=config.env_config.request_url,
         runs=1,
         output_path=output_file,
         chrome_path=config.chrome_bin,

--- a/blaze/mahimahi/mahimahi.py
+++ b/blaze/mahimahi/mahimahi.py
@@ -73,7 +73,7 @@ class MahiMahiConfig():
     """
     return [
       'mm-proxyreplay',
-      self.config.train_config.replay_dir,
+      self.config.env_config.replay_dir,
       self.config.nghttpx_bin,
       os.path.join(self.config.mahimahi_cert_dir, 'reverse_proxy_key.pem'),
       os.path.join(self.config.mahimahi_cert_dir, 'reverse_proxy_cert.pem'),

--- a/blaze/model/apex.py
+++ b/blaze/model/apex.py
@@ -36,7 +36,7 @@ def train(train_config: TrainConfig, config: Config):
         "env_config": config,
       },
     },
-  }, resume='prompt', reuse_actors=True)
+  }, resume='prompt')
 
 def get_model(location: str):
   """ Returns a SavedModel for instantiation given a model checkpoint directory """

--- a/blaze/model/apex.py
+++ b/blaze/model/apex.py
@@ -36,7 +36,7 @@ def train(train_config: TrainConfig, config: Config):
         "env_config": config,
       },
     },
-  }, resume='prompt')
+  }, resume='prompt', reuse_actors=True)
 
 def get_model(location: str):
   """ Returns a SavedModel for instantiation given a model checkpoint directory """

--- a/blaze/model/apex.py
+++ b/blaze/model/apex.py
@@ -13,7 +13,7 @@ def train(train_config: TrainConfig, config: Config):
   ray.init(num_cpus=train_config.num_cpus)
 
   name = train_config.experiment_name
-  total_urls = sum(len(group.resources) for group in config.train_config.push_groups)
+  total_urls = sum(len(group.resources) for group in config.env_config.push_groups)
   ray.tune.run_experiments({
     name : {
       "run": "APEX",

--- a/blaze/model/model.py
+++ b/blaze/model/model.py
@@ -30,7 +30,8 @@ class ModelInstance():
     if self.policy is not None:
       return self.policy
     # create ActionSpace and Policy objects to record the actions taken by the agent
-    action_space = ActionSpace(self.env_config.push_groups)
+    trainable_push_groups = [group for group in self.env_config.push_groups if group.trainable]
+    action_space = ActionSpace(trainable_push_groups)
     self.policy = Policy(action_space)
     # create the initial observation from the environment that gets passed to the agent
     observation = get_observation(self.client_environment, self.env_config.push_groups, self.policy)

--- a/blaze/model/ppo.py
+++ b/blaze/model/ppo.py
@@ -33,7 +33,7 @@ def train(train_config: TrainConfig, config: Config):
         "env_config": config,
       },
     },
-  }, resume='prompt')
+  }, resume='prompt', reuse_actors=True)
 
 def get_model(location: str):
   """ Returns a SavedModel for instantiation given a model checkpoint directory """

--- a/blaze/model/ppo.py
+++ b/blaze/model/ppo.py
@@ -33,7 +33,7 @@ def train(train_config: TrainConfig, config: Config):
         "env_config": config,
       },
     },
-  }, resume='prompt', reuse_actors=True)
+  }, resume='prompt')
 
 def get_model(location: str):
   """ Returns a SavedModel for instantiation given a model checkpoint directory """

--- a/blaze/preprocess/resource.py
+++ b/blaze/preprocess/resource.py
@@ -5,14 +5,15 @@ from blaze.config.environment import PushGroup, Resource, ResourceType
 from blaze.proto import policy_service_pb2
 from .url import Url
 
-def resource_list_to_push_groups(res_list: List[Resource]) -> List[PushGroup]:
+def resource_list_to_push_groups(res_list: List[Resource], train_domain_suffix="") -> List[PushGroup]:
   """ Convert an ordered list of resources to a list of PushGroups """
   # extract the list of domains and sort
   domains = sorted(list(set(Url.parse(res.url).domain for res in res_list)))
   # map domain to push group
   domain_to_push_group = {domain: i for (i, domain) in enumerate(domains)}
   # create the push groups
-  push_groups = [PushGroup(group_name=domain, resources=[]) for domain in domains]
+  push_groups = [PushGroup(group_name=domain, resources=[], trainable=domain.endswith(train_domain_suffix))
+                 for domain in domains]
 
   for (order, res) in enumerate(res_list):
     url = Url.parse(res.url)

--- a/blaze/serve/policy_service.py
+++ b/blaze/serve/policy_service.py
@@ -7,6 +7,7 @@ from blaze.config import client
 from blaze.config import environment
 from blaze.model.model import ModelInstance, SavedModel
 from blaze.preprocess.resource import convert_policy_resource_to_environment_resource, resource_list_to_push_groups
+from blaze.preprocess.url import Url
 from blaze.proto import policy_service_pb2
 from blaze.proto import policy_service_pb2_grpc
 
@@ -37,9 +38,10 @@ class PolicyService(policy_service_pb2_grpc.PolicyServiceServicer):
   def create_model_instance(self, page: policy_service_pb2.Page) -> ModelInstance:
     """ Instantiates a model for the given page """
     # convert page resources to ordered push groups
+    url = Url.parse(page.url)
     page_resources = sorted(page.resources, key=lambda r: r.timestamp)
     page_resources = list(map(convert_policy_resource_to_environment_resource, page_resources))
-    push_groups = resource_list_to_push_groups(page_resources)
+    push_groups = resource_list_to_push_groups(page_resources, train_domain_suffix=url.domain)
     # convert page network_type and device_speed to client environment
     client_environment = client.ClientEnvironment(
       device_speed=client.DeviceSpeed(page.device_speed),

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,6 @@ tensorflow-estimator==1.13.0
 termcolor==1.1.0
 typed-ast==1.3.1
 typing==3.6.6
-urllib3==1.24.1
+urllib3==1.24.2
 Werkzeug==0.15.2
 wrapt==1.11.1

--- a/tests/action/test_action.py
+++ b/tests/action/test_action.py
@@ -52,9 +52,6 @@ class TestActionSpace():
     push_pairs = convert_push_groups_to_push_pairs(self.push_groups)
     pushable_resources = set(v.url for (k, v) in push_pairs)
     assert len(self.action_space.push_resources) == len(pushable_resources)
-    for (i, res) in enumerate(self.action_space.push_resources):
-      # skipping the zeroth one (noop) and first one (can't push the first resource)
-      assert res.order == i + 2
 
   def test_init_actions(self):
     push_pairs = convert_push_groups_to_push_pairs(self.push_groups)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -14,7 +14,7 @@ class TestConfig():
       chrome_bin='',
     )
     assert isinstance(conf, config.Config)
-    assert conf.train_config is None
+    assert conf.env_config is None
 
   def test_items(self):
     conf = config.get_config()
@@ -31,11 +31,11 @@ class TestGetConfig():
     assert conf.pwmetrics_bin == config.DEFAULT_PWMETRICS_BIN
     assert conf.nghttpx_bin == config.DEFAULT_NGHTTPX_BIN
     assert conf.chrome_bin == config.DEFAULT_CHROME_BIN
-    assert conf.train_config is None
+    assert conf.env_config is None
 
   def test_get_config_with_env_config(self):
     conf = config.get_config(get_env_config())
-    assert conf.train_config == get_env_config()
+    assert conf.env_config == get_env_config()
 
   @mock.patch.dict(os.environ, {'CHROME_BIN': 'test_chrome', 'MAHIMAHI_CERT_DIR': 'test_mm_dir'})
   def test_get_config_with_override(self):
@@ -46,4 +46,4 @@ class TestGetConfig():
     assert conf.pwmetrics_bin == config.DEFAULT_PWMETRICS_BIN
     assert conf.nghttpx_bin == config.DEFAULT_NGHTTPX_BIN
     assert conf.chrome_bin == 'test_chrome'
-    assert conf.train_config is None
+    assert conf.env_config is None

--- a/tests/environment/test_environment.py
+++ b/tests/environment/test_environment.py
@@ -28,7 +28,7 @@ class TestEnvironment():
     assert isinstance(env.action_space, ActionSpace)
     assert isinstance(env.analyzer, Analyzer)
     assert isinstance(env.policy, Policy)
-    assert env.config.train_config.push_groups == env.action_space.push_groups
+    assert env.config.env_config.push_groups == env.action_space.push_groups
     assert env.policy.action_space == env.action_space
 
   def test_init_with_dict_env(self):
@@ -87,7 +87,7 @@ class TestEnvironment():
       assert info['action'] == action
       assert self.environment.policy.actions_taken == 1
       assert self.environment.policy.resource_pushed_from(action.push) == action.source
-      assert obs['resources'][str(action.push.order)][3] == action.source.order
+      assert obs['resources'][str(action.push.order)][3] == action.source.order + 1
     finally:
       self.environment.reset()
 

--- a/tests/environment/test_observation.py
+++ b/tests/environment/test_observation.py
@@ -56,7 +56,8 @@ class TestGetObservation():
       # make sure the push sources are recorded correctly
       for (source, push) in policy:
         for push_res in push:
-          assert obs['resources'][str(push_res.order)][3] == source.order
+          # +1 since we have defined it that way
+          assert obs['resources'][str(push_res.order)][3] == source.order + 1
 
       # check that all other resources are not pushed
       pushed_res = set(push_res.order for (source, push) in policy for push_res in push)

--- a/tests/environment/test_observation.py
+++ b/tests/environment/test_observation.py
@@ -1,3 +1,5 @@
+import random
+
 import gym
 
 from blaze.action import ActionSpace, Policy
@@ -61,6 +63,42 @@ class TestGetObservation():
 
       # check that all other resources are not pushed
       pushed_res = set(push_res.order for (source, push) in policy for push_res in push)
+      assert all(res[3] == 0
+                 for order, res in obs['resources'].items()
+                 if int(order) not in pushed_res)
+
+  def test_observation_with_nonempty_policy_with_default_actions(self):
+    # use all push groups except the chosen default group
+    candidate_push_groups = [i for i, group in enumerate(self.push_groups)
+                             if len(group.resources) > 2 and not group.trainable]
+    default_group_idx = random.choice(candidate_push_groups)
+    default_group = self.push_groups[default_group_idx]
+    remaining_groups = [group for i, group in enumerate(self.push_groups) if i != default_group_idx]
+    action_space = ActionSpace(remaining_groups)
+    policy = Policy(action_space)
+
+    # apply some default action
+    for push in default_group.resources[1:]:
+      policy.add_default_action(default_group.resources[0], push)
+
+    # do some actions and check the observation space over time
+    for _ in range(len(action_space) - 1):
+      # get an action and apply it in the policy
+      action_id = action_space.sample()
+      policy.apply_action(action_id)
+
+      # get the observation
+      obs = get_observation(self.client_environment, self.push_groups, policy)
+      assert self.observation_space.contains(obs)
+
+      # make sure the push sources are recorded correctly according to the observable policy
+      for (source, push) in policy.observable:
+        for push_res in push:
+          # +1 since we have defined it that way
+          assert obs['resources'][str(push_res.order)][3] == source.order + 1
+
+      # check that all other resources are not pushed according to the observable policy
+      pushed_res = set(push_res.order for (source, push) in policy.observable for push_res in push)
       assert all(res[3] == 0
                  for order, res in obs['resources'].items()
                  if int(order) not in pushed_res)

--- a/tests/evaluator/test_analyzer.py
+++ b/tests/evaluator/test_analyzer.py
@@ -10,7 +10,7 @@ from tests.mocks.config import get_config
 class TestAnalyzer():
   def setup(self):
     self.config = get_config()
-    self.policy = Policy(ActionSpace(self.config.train_config.push_groups))
+    self.policy = Policy(ActionSpace(self.config.env_config.push_groups))
     self.client_environment = get_random_client_environment()
 
   def get_analyzer(self):

--- a/tests/mahimahi/test_mahimahi.py
+++ b/tests/mahimahi/test_mahimahi.py
@@ -102,7 +102,7 @@ class TestMahiMahiConfig():
     mm_config = MahiMahiConfig(self.config, self.policy)
     proxy_replay_cmd = mm_config.proxy_replay_cmd
     assert proxy_replay_cmd[0] == 'mm-proxyreplay'
-    assert proxy_replay_cmd[1] == self.config.train_config.replay_dir
+    assert proxy_replay_cmd[1] == self.config.env_config.replay_dir
     assert proxy_replay_cmd[2] == self.config.nghttpx_bin
     assert proxy_replay_cmd[3].startswith(self.config.mahimahi_cert_dir)
     assert proxy_replay_cmd[3].endswith('reverse_proxy_key.pem')

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -58,7 +58,7 @@ def get_serve_config() -> ServeConfig:
   )
 
 def get_config() -> Config:
-  return Config(**{**_get_config()._asdict(), 'train_config': get_env_config()})
+  return Config(**{**_get_config()._asdict(), 'env_config': get_env_config()})
 
 def get_mahimahi_config() -> MahiMahiConfig:
   return MahiMahiConfig(

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -12,6 +12,7 @@ def get_push_groups() -> List[PushGroup]:
   return [
     PushGroup(
       group_name='example.com',
+      trainable=True,
       resources=[
         Resource(url='http://example.com/A', size=1024, order=0, group_id=0, source_id=0, type=ResourceType.IMAGE),
         Resource(url='http://example.com/B', size=1024, order=3, group_id=0, source_id=1, type=ResourceType.IMAGE),
@@ -21,10 +22,20 @@ def get_push_groups() -> List[PushGroup]:
     ),
     PushGroup(
       group_name='sub.example.com',
+      trainable=True,
       resources=[
         Resource(url='http://sub.example.com/D', size=1024, order=1, group_id=1, source_id=0, type=ResourceType.IMAGE),
         Resource(url='http://sub.example.com/E', size=1024, order=2, group_id=1, source_id=1, type=ResourceType.IMAGE),
         Resource(url='http://sub.example.com/G', size=1024, order=5, group_id=1, source_id=2, type=ResourceType.IMAGE),
+      ],
+    ),
+    PushGroup(
+      group_name='zz.ads.googleads.com',
+      trainable=False,
+      resources=[
+        Resource(url='http://zz.ads.googleads.com/script.1.js', size=1024, order=7, group_id=2, source_id=0, type=ResourceType.SCRIPT),
+        Resource(url='http://zz.ads.googleads.com/script.2.js', size=1024, order=8, group_id=2, source_id=1, type=ResourceType.SCRIPT),
+        Resource(url='http://zz.ads.googleads.com/script.3.js', size=1024, order=9, group_id=2, source_id=2, type=ResourceType.SCRIPT),
       ],
     ),
   ]

--- a/tests/mocks/serve.py
+++ b/tests/mocks/serve.py
@@ -5,7 +5,7 @@ from blaze.proto import policy_service_pb2
 
 from tests.mocks.config import get_push_groups
 
-def get_page(url: str, client_environment = get_random_client_environment()) -> policy_service_pb2.Page:
+def get_page(url: str, client_environment=get_random_client_environment()) -> policy_service_pb2.Page:
   push_groups = get_push_groups()
   resources = [res for group in push_groups for res in group.resources]
   page_resources = [policy_service_pb2.Resource(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -30,7 +30,7 @@ class TestModelInstance():
     assert policy
     assert policy.completed
     assert len(mock_agent.observations) == len(policy)
-    assert all((source, push) in push_pairs for (push, source) in policy.push_to_source.items())
+    assert all((source, p) in push_pairs for (source, push) in policy for p in push)
     assert all(observation_space.contains(obs) for obs in mock_agent.observations)
 
   def test_push_policy_returns_cached_policy(self):

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -11,6 +11,7 @@ class TestModelInstance():
   def setup(self):
     self.client_environment = get_random_client_environment()
     self.env_config = get_env_config()
+    self.trainable_push_groups = [group for group in self.env_config.push_groups if group.trainable]
 
   def test_init(self):
     action_space = ActionSpace(self.env_config.push_groups)
@@ -21,9 +22,9 @@ class TestModelInstance():
     assert not m.policy
 
   def test_push_policy(self):
-    push_pairs = convert_push_groups_to_push_pairs(self.env_config.push_groups)
+    push_pairs = convert_push_groups_to_push_pairs(self.trainable_push_groups)
     observation_space = get_observation_space()
-    action_space = ActionSpace(self.env_config.push_groups)
+    action_space = ActionSpace(self.trainable_push_groups)
     mock_agent = MockAgent(action_space)
     m = ModelInstance(mock_agent, self.env_config, self.client_environment)
     policy = m.push_policy
@@ -34,7 +35,7 @@ class TestModelInstance():
     assert all(observation_space.contains(obs) for obs in mock_agent.observations)
 
   def test_push_policy_returns_cached_policy(self):
-    action_space = ActionSpace(self.env_config.push_groups)
+    action_space = ActionSpace(self.trainable_push_groups)
     mock_agent = MockAgent(action_space)
     m = ModelInstance(mock_agent, self.env_config, self.client_environment)
     first_policy = m.push_policy

--- a/tests/preprocess/test_resource.py
+++ b/tests/preprocess/test_resource.py
@@ -11,6 +11,19 @@ class TestResourceListToPushGroups():
   def test_resource_list_to_push_groups(self):
     push_groups = resource_list_to_push_groups(self.resources)
     for g, group in enumerate(push_groups):
+      assert group.trainable
+      assert group.group_name == self.push_groups[g].group_name
+      for res, actual in zip(group.resources, self.push_groups[g].resources):
+        assert res.url == actual.url
+        assert res.order == actual.order
+        assert res.type == actual.type
+        assert res.source_id == actual.source_id
+        assert res.group_id == g
+
+  def test_resource_list_to_push_groups_with_domain_suffix(self):
+    push_groups = resource_list_to_push_groups(self.resources, train_domain_suffix="example.com")
+    for g, group in enumerate(push_groups):
+      assert group.trainable == self.push_groups[g].trainable
       assert group.group_name == self.push_groups[g].group_name
       for res, actual in zip(group.resources, self.push_groups[g].resources):
         assert res.url == actual.url

--- a/tests/serve/test_policy_service.py
+++ b/tests/serve/test_policy_service.py
@@ -14,7 +14,8 @@ class TestPolicyService():
     self.client_environment = get_random_client_environment()
     self.page = get_page("http://example.com", self.client_environment)
     self.push_groups = get_push_groups()
-    self.action_space = ActionSpace(self.push_groups)
+    self.trainable_push_groups = [group for group in self.push_groups if group.trainable]
+    self.action_space = ActionSpace(self.trainable_push_groups)
     self.saved_model = SavedModel(mock_agent_with_action_space(self.action_space), Environment, "")
 
   def test_init(self):

--- a/tests/serve/test_server.py
+++ b/tests/serve/test_server.py
@@ -16,8 +16,9 @@ from tests.mocks.serve import get_page
 class TestServer():
   def setup(self):
     self.push_groups = get_push_groups()
+    self.trainable_push_groups = [group for group in self.push_groups if group.trainable]
     self.serve_config = get_serve_config()
-    self.action_space = ActionSpace(self.push_groups)
+    self.action_space = ActionSpace(self.trainable_push_groups)
     self.mock_agent = mock_agent_with_action_space(self.action_space)
     self.saved_model = SavedModel(self.mock_agent, Environment, "/tmp/model_location")
 


### PR DESCRIPTION
- Adds `trainable` to push group, indicating which push groups should be trained
- Randomly selects a group that is not `trainable` to simulate as always pushing
- Adds `train_domain_suffix` to indicate during preprocessing which push groups to consider trainable