### PR TITLE
Reduce action space size and max policy length

### DIFF
--- a/blaze/action/action_space.py
+++ b/blaze/action/action_space.py
@@ -31,10 +31,11 @@ class ActionSpace(gym.spaces.Discrete):
         self.action_id_map: Dict[Tuple[int, int, int], int] = {}
         self.actions: List[Action] = [Action()]
         for group in push_groups:
+            max_depth = max(20, len(group.resources) // 3)
             for source in group.resources:
                 if source.source_id != 0:
                     self.push_resources.append(source)
-                for push in group.resources[source.source_id + 1 :]:
+                for push in group.resources[source.source_id + 1 : (source.source_id + 1 + max_depth)]:
                     self.action_id_map[(group.id, source.source_id, push.source_id)] = len(self.actions)
                     self.actions.append(Action(len(self.actions), source, push))
         self.push_resources.sort(key=lambda r: r.order)

--- a/blaze/action/policy.py
+++ b/blaze/action/policy.py
@@ -37,7 +37,7 @@ class Policy:
     @property
     def completed(self):
         """ Returns true if all actions have been taken """
-        return self.actions_taken >= self.total_actions
+        return self.actions_taken >= min(self.total_actions, max(10, self.total_actions // 2))
 
     @property
     def observable(self):

--- a/tests/action/test_policy.py
+++ b/tests/action/test_policy.py
@@ -36,6 +36,30 @@ class TestPolicy:
             policy.apply_action(0)
         assert policy.completed
 
+    def test_completed_when_small_number_of_actions(self):
+        policy = Policy(ActionSpace(self.push_groups))
+        policy.total_actions = 5
+        policy.actions_taken = 5
+        assert policy.completed
+        policy.actions_taken = 4
+        assert not policy.completed
+
+    def test_completed_when_medium_number_of_action(self):
+        policy = Policy(ActionSpace(self.push_groups))
+        policy.total_actions = 15
+        policy.actions_taken = 10
+        assert policy.completed
+        policy.actions_taken = 9
+        assert not policy.completed
+
+    def test_completed_when_large_number_of_actions(self):
+        policy = Policy(ActionSpace(self.push_groups))
+        policy.total_actions = 40
+        policy.actions_taken = 20
+        assert policy.completed
+        policy.actions_taken = 19
+        assert not policy.completed
+
     def test_as_dict(self):
         action_space = ActionSpace(self.push_groups)
         policy = Policy(action_space)


### PR DESCRIPTION
- Maximum push-lookahead is `max(20, len(group.resources) // 3)`
- Maximum policy length is `min(len(action_space), max(10, len(action_space) // 2))`