### PR TITLE
Fix apex model timesteps_per_iteration

### DIFF
--- a/blaze/action/policy.py
+++ b/blaze/action/policy.py
@@ -36,17 +36,18 @@ class Policy:
 
     @property
     def total_steps(self):
-        """ Returns the maximum number of steps  to take before completing the policy """
+        """ Returns the maximum number of steps to take before completing the policy """
         return min(self.total_actions, max(10, self.total_actions // 2))
 
     @property
     def steps_remaining(self):
+        """ Returns the number of steps remaining before the policy is complete """
         return self.total_steps - self.steps_taken
 
     @property
     def completed(self):
-        """ Returns true if all actions have been taken """
-        return self.steps_taken >= self.total_steps
+        """ Returns true if all steps have been taken """
+        return self.steps_remaining <= 0
 
     @property
     def observable(self):

--- a/blaze/action/policy.py
+++ b/blaze/action/policy.py
@@ -20,7 +20,7 @@ class Policy:
     def __init__(self, action_space: ActionSpace):
         self.action_space = action_space
         self.total_actions = len(action_space)
-        self.actions_taken = 0
+        self.steps_taken = 0
         self.push_to_source = {}
         self.source_to_push = collections.defaultdict(set)
         self.default_source_to_push = collections.defaultdict(set)
@@ -32,12 +32,21 @@ class Policy:
         return iter(source_to_push.items())
 
     def __len__(self):
-        return self.actions_taken
+        return self.steps_taken
+
+    @property
+    def total_steps(self):
+        """ Returns the maximum number of steps  to take before completing the policy """
+        return min(self.total_actions, max(10, self.total_actions // 2))
+
+    @property
+    def steps_remaining(self):
+        return self.total_steps - self.steps_taken
 
     @property
     def completed(self):
         """ Returns true if all actions have been taken """
-        return self.actions_taken >= min(self.total_actions, max(10, self.total_actions // 2))
+        return self.steps_taken >= self.total_steps
 
     @property
     def observable(self):
@@ -64,7 +73,7 @@ class Policy:
             self.push_to_source[action.push] = action.source
             self.source_to_push[action.source].add(action.push)
             self.action_space.use_action(action)
-        self.actions_taken += 1
+        self.steps_taken += 1
         return not action.is_noop
 
     def add_default_action(self, source: Resource, push: Resource):

--- a/blaze/environment/environment.py
+++ b/blaze/environment/environment.py
@@ -79,7 +79,7 @@ class Environment(gym.Env):
             "trying action",
             action=repr(decoded_action),
             steps_taken=self.policy.steps_taken,
-            steps_remaining=self.policy.steps_remaining
+            steps_remaining=self.policy.steps_remaining,
         )
 
         reward = NOOP_ACTION_REWARD

--- a/blaze/environment/environment.py
+++ b/blaze/environment/environment.py
@@ -75,14 +75,20 @@ class Environment(gym.Env):
     def step(self, action):
         decoded_action = self.action_space.decode_action_id(action)
         action_applied = self.policy.apply_action(action)
-        log.info("trying action", action=repr(decoded_action), total_actions=self.policy.actions_taken)
+        log.info(
+            "trying action",
+            action=repr(decoded_action),
+            steps_taken=self.policy.steps_taken,
+            steps_remaining=self.policy.steps_remaining
+        )
 
         reward = NOOP_ACTION_REWARD
         if action_applied:
             reward = self.analyzer.get_reward(self.policy) or NOOP_ACTION_REWARD
         log.info("got reward", action=repr(decoded_action), reward=reward)
 
-        return self.observation, reward, self.policy.completed, {"action": decoded_action}
+        info = {"action": decoded_action, "policy": self.policy.as_dict}
+        return self.observation, reward, self.policy.completed, info
 
     def render(self, mode="human"):
         return super(Environment, self).render(mode=mode)

--- a/blaze/model/apex.py
+++ b/blaze/model/apex.py
@@ -1,5 +1,6 @@
 """ This module defines the model for training and instantiating APEX agents """
 
+from blaze.action import ActionSpace, Policy
 from blaze.config.config import Config
 from blaze.config.train import TrainConfig
 from blaze.environment import Environment
@@ -11,12 +12,14 @@ def train(train_config: TrainConfig, config: Config):
     """ Trains an APEX agent with the given training and environment configuration """
     # lazy load modules so that they aren't imported if they're not necessary
     import ray
+    from ray.tune import run_experiments
 
     ray.init(num_cpus=train_config.num_cpus)
 
+    action_space = ActionSpace(config.env_config.trainable_push_groups)
+    policy = Policy(action_space)
     name = train_config.experiment_name
-    total_urls = sum(len(group.resources) for group in config.env_config.push_groups)
-    ray.tune.run_experiments(
+    run_experiments(
         {
             name: {
                 "run": "APEX",
@@ -28,8 +31,8 @@ def train(train_config: TrainConfig, config: Config):
                 "config": {
                     "sample_batch_size": 50,
                     "train_batch_size": 512,
-                    "timesteps_per_iteration": total_urls,
-                    "target_network_update_freq": total_urls * 5,
+                    "timesteps_per_iteration": policy.total_steps,
+                    "target_network_update_freq": policy.total_steps * 4,
                     "batch_mode": "complete_episodes",
                     "collect_metrics_timeout": 1200,
                     "num_workers": train_config.num_cpus // 2,

--- a/blaze/model/apex.py
+++ b/blaze/model/apex.py
@@ -16,8 +16,7 @@ def train(train_config: TrainConfig, config: Config):
 
     ray.init(num_cpus=train_config.num_cpus)
 
-    action_space = ActionSpace(config.env_config.trainable_push_groups)
-    policy = Policy(action_space)
+    policy = Policy(ActionSpace(config.env_config.trainable_push_groups))
     name = train_config.experiment_name
     run_experiments(
         {

--- a/blaze/model/ppo.py
+++ b/blaze/model/ppo.py
@@ -11,11 +11,12 @@ def train(train_config: TrainConfig, config: Config):
     """ Trains an PPO agent with the given training and environment configuration """
     # lazy load modules so that they aren't imported if they're not necessary
     import ray
+    from ray.tune import run_experiments
 
     ray.init(num_cpus=train_config.num_cpus)
 
     name = train_config.experiment_name
-    ray.tune.run_experiments(
+    run_experiments(
         {
             name: {
                 "run": "PPO",

--- a/tests/action/test_policy.py
+++ b/tests/action/test_policy.py
@@ -39,25 +39,25 @@ class TestPolicy:
     def test_completed_when_small_number_of_actions(self):
         policy = Policy(ActionSpace(self.push_groups))
         policy.total_actions = 5
-        policy.actions_taken = 5
+        policy.steps_taken = 5
         assert policy.completed
-        policy.actions_taken = 4
+        policy.steps_taken = 4
         assert not policy.completed
 
     def test_completed_when_medium_number_of_action(self):
         policy = Policy(ActionSpace(self.push_groups))
         policy.total_actions = 15
-        policy.actions_taken = 10
+        policy.steps_taken = 10
         assert policy.completed
-        policy.actions_taken = 9
+        policy.steps_taken = 9
         assert not policy.completed
 
     def test_completed_when_large_number_of_actions(self):
         policy = Policy(ActionSpace(self.push_groups))
         policy.total_actions = 40
-        policy.actions_taken = 20
+        policy.steps_taken = 20
         assert policy.completed
-        policy.actions_taken = 19
+        policy.steps_taken = 19
         assert not policy.completed
 
     def test_as_dict(self):

--- a/tests/environment/test_environment.py
+++ b/tests/environment/test_environment.py
@@ -55,12 +55,12 @@ class TestEnvironment:
         # step the environment and check that an action was successfully taken
         self.environment.step(action_id)
         assert len(self.environment.action_space) < num_push_resources
-        assert self.environment.policy.actions_taken == 1
+        assert self.environment.policy.steps_taken == 1
 
         # check that resetting the environment works
         obs = self.environment.reset()
         assert len(self.environment.action_space) == num_push_resources
-        assert self.environment.policy.actions_taken == 0
+        assert self.environment.policy.steps_taken == 0
         assert obs and isinstance(obs, dict)
         assert self.environment.observation_space.contains(obs)
 
@@ -84,7 +84,7 @@ class TestEnvironment:
             obs, reward, _, info = self.environment.step(noop_action.action_id)
             assert reward == NOOP_ACTION_REWARD
             assert info["action"] == noop_action
-            assert self.environment.policy.actions_taken == 1
+            assert self.environment.policy.steps_taken == 1
             # res[3] refers to the third item in the resource_space for res
             assert all(res[3] == 0 for res in obs["resources"].values())
         finally:
@@ -103,7 +103,7 @@ class TestEnvironment:
             assert reward == action_rew
             assert not complete
             assert info["action"] == action
-            assert self.environment.policy.actions_taken == 1
+            assert self.environment.policy.steps_taken == 1
             assert self.environment.policy.resource_pushed_from(action.push) == action.source
             assert obs["resources"][str(action.push.order)][3] == action.source.order + 1
         finally:


### PR DESCRIPTION
The `timesteps_per_iteration` property was not correct given that we don't train all URLs and we don't train until we generate the maximum possible push policy. This has been corrected to be only until the policy completes, which is determined by `policy.total_steps`.