### PR TITLE
Add option to output push policy in mahimahi format

### DIFF
--- a/blaze/action/policy.py
+++ b/blaze/action/policy.py
@@ -7,7 +7,7 @@ representation and the actual URL representation
 import collections
 from typing import Optional
 
-from blaze.config.environment import Resource
+from blaze.config.environment import Resource, ResourceType
 from .action_space import ActionSpace
 
 
@@ -91,3 +91,21 @@ class Policy:
         if push not in self.push_to_source:
             return None
         return self.push_to_source[push]
+
+    @staticmethod
+    def from_dict(policy_dict: dict):
+        """
+        Returns a Policy instantiated from a simple dictionary of source URLs to lists of push URLs. The returned
+        Policy will only be useful for display purposes, as the action space will be instantiated with an empty
+        list of push groups.
+        """
+        policy = Policy(ActionSpace([]))
+        for (source, deps) in policy_dict.items():
+            policy.source_to_push[Resource(url=source, size=0, type=ResourceType.NONE)] = set(
+                Resource(url=push, size=0, type=ResourceType.NONE) for push in deps
+            )
+            for push in deps:
+                policy.push_to_source[Resource(url=push, size=0, type=ResourceType.NONE)] = Resource(
+                    url=source, size=0, type=ResourceType.NONE
+                )
+        return policy

--- a/blaze/command/serve.py
+++ b/blaze/command/serve.py
@@ -8,7 +8,7 @@ from blaze.logger import logger as log
 from . import command
 
 
-@command.argument("location", help="The path to the folder containing the saved model")
+@command.argument("location", help="The path to the saved model")
 @command.argument(
     "--model",
     help="The RL technique used during training for the saved model",
@@ -34,8 +34,8 @@ def serve(args):
     )
 
     # check that the passed model location exists
-    if not os.path.exists(args.location) or not os.path.isdir(args.location):
-        raise IOError("The model location must be a valid directory")
+    if not os.path.exists(args.location) or not os.path.isfile(args.location):
+        raise IOError("The model location must be a valid file")
 
     # lazy load import statements
     from blaze.serve.server import Server

--- a/tests/action/test_policy.py
+++ b/tests/action/test_policy.py
@@ -1,6 +1,7 @@
 import itertools
 
 from blaze.action import Action, ActionSpace, Policy
+from blaze.config.environment import Resource
 
 from tests.mocks.config import get_push_groups
 
@@ -154,3 +155,17 @@ class TestPolicy:
         assert policy.resource_pushed_from(action.push) is None
         assert policy.apply_action(action_id)
         assert policy.resource_pushed_from(action.push) is action.source
+
+    def test_from_dict(self):
+        policy_dict = {"A": ["B", "C"], "B": ["D", "E", "F"]}
+        policy = Policy.from_dict(policy_dict)
+        assert policy.total_actions == 0
+        assert policy.action_space is not None
+        for (source, deps) in policy:
+            assert isinstance(source, Resource)
+            assert all(isinstance(push, Resource) for push in deps)
+            assert sorted(policy_dict[source.url]) == sorted([push.url for push in deps])
+            for push in deps:
+                assert policy.push_to_source[push] == source
+                assert push.url in policy_dict[source.url]
+        assert len(policy.source_to_push) == len(policy_dict)

--- a/tests/command/test_client.py
+++ b/tests/command/test_client.py
@@ -65,3 +65,38 @@ class TestClient:
             assert len(policy) > 0
         finally:
             server.stop()
+
+    def test_client_mahimahi_format(self, capsys):
+        server = Server(self.serve_config)
+        server.set_policy_service(PolicyService(self.saved_model))
+
+        try:
+            server.start()
+
+            with tempfile.NamedTemporaryFile() as manifest_file:
+                config = EnvironmentConfig(
+                    request_url="http://cs.ucla.edu/", replay_dir="/tmp/tmp_dir", push_groups=get_push_groups()
+                )
+                config.save_file(manifest_file.name)
+                query(
+                    [
+                        "--manifest",
+                        manifest_file.name,
+                        "-n",
+                        "1",
+                        "-d",
+                        "2",
+                        "--host",
+                        str(self.serve_config.host),
+                        "--port",
+                        str(self.serve_config.port),
+                        "--mahimahi_format",
+                    ]
+                )
+
+            policy = capsys.readouterr().out
+            assert policy
+            assert len(policy.split("\n")) > 0
+            assert len(policy.split("\n")[0].split("\t")) > 1
+        finally:
+            server.stop()

--- a/tests/command/test_serve.py
+++ b/tests/command/test_serve.py
@@ -20,7 +20,7 @@ class TestServe:
 
     def test_serve_invalid_model_location(self):
         with pytest.raises(IOError):
-            serve(["--model", "APEX", "/non/existent/dir"])
+            serve(["--model", "APEX", "/non/existent/file"])
 
     @mock.patch("time.sleep")
     @mock.patch("ray.init")
@@ -28,16 +28,26 @@ class TestServe:
     def test_serve_a3c(self, mock_shutdown, mock_init, mock_sleep):
         mock_sleep.side_effect = (KeyboardInterrupt(), None, None, None, None)
         with mock.patch("blaze.serve.server.Server", new=MockServer()) as mock_server:
-            with tempfile.TemporaryDirectory() as model_location:
+            with tempfile.NamedTemporaryFile() as model_location:
                 serve(
-                    ["--model", "A3C", "--port", "5678", "--host", "127.0.0.1", "--max_workers", "16", model_location]
+                    [
+                        "--model",
+                        "A3C",
+                        "--port",
+                        "5678",
+                        "--host",
+                        "127.0.0.1",
+                        "--max_workers",
+                        "16",
+                        model_location.name,
+                    ]
                 )
 
         assert mock_server.args[0].host == "127.0.0.1"
         assert mock_server.args[0].port == 5678
         assert mock_server.args[0].max_workers == 16
         assert mock_server.set_policy_service_args[0].saved_model.cls == A3CAgent
-        assert mock_server.set_policy_service_args[0].saved_model.location == model_location
+        assert mock_server.set_policy_service_args[0].saved_model.location == model_location.name
         assert mock_server.start_called
         assert mock_server.stop_called
 
@@ -47,16 +57,26 @@ class TestServe:
     def test_serve_apex(self, mock_shutdown, mock_init, mock_sleep):
         mock_sleep.side_effect = (KeyboardInterrupt(), None, None, None, None)
         with mock.patch("blaze.serve.server.Server", new=MockServer()) as mock_server:
-            with tempfile.TemporaryDirectory() as model_location:
+            with tempfile.NamedTemporaryFile() as model_location:
                 serve(
-                    ["--model", "APEX", "--port", "5678", "--host", "127.0.0.1", "--max_workers", "16", model_location]
+                    [
+                        "--model",
+                        "APEX",
+                        "--port",
+                        "5678",
+                        "--host",
+                        "127.0.0.1",
+                        "--max_workers",
+                        "16",
+                        model_location.name,
+                    ]
                 )
 
         assert mock_server.args[0].host == "127.0.0.1"
         assert mock_server.args[0].port == 5678
         assert mock_server.args[0].max_workers == 16
         assert mock_server.set_policy_service_args[0].saved_model.cls == ApexAgent
-        assert mock_server.set_policy_service_args[0].saved_model.location == model_location
+        assert mock_server.set_policy_service_args[0].saved_model.location == model_location.name
         assert mock_server.start_called
         assert mock_server.stop_called
 
@@ -66,15 +86,25 @@ class TestServe:
     def test_serve_ppo(self, mock_shutdown, mock_init, mock_sleep):
         mock_sleep.side_effect = KeyboardInterrupt()
         with mock.patch("blaze.serve.server.Server", new=MockServer()) as mock_server:
-            with tempfile.TemporaryDirectory() as model_location:
+            with tempfile.NamedTemporaryFile() as model_location:
                 serve(
-                    ["--model", "PPO", "--port", "5678", "--host", "127.0.0.1", "--max_workers", "16", model_location]
+                    [
+                        "--model",
+                        "PPO",
+                        "--port",
+                        "5678",
+                        "--host",
+                        "127.0.0.1",
+                        "--max_workers",
+                        "16",
+                        model_location.name,
+                    ]
                 )
 
         assert mock_server.args[0].host == "127.0.0.1"
         assert mock_server.args[0].port == 5678
         assert mock_server.args[0].max_workers == 16
         assert mock_server.set_policy_service_args[0].saved_model.cls == PPOAgent
-        assert mock_server.set_policy_service_args[0].saved_model.location == model_location
+        assert mock_server.set_policy_service_args[0].saved_model.location == model_location.name
         assert mock_server.start_called
         assert mock_server.stop_called


### PR DESCRIPTION
The client can write the push policy in the format of a mahimahi dependency file. This makes it easier to query the model for a push policy and test it in Mahimahi.