### PR TITLE
Add Time-Based Stopping Criteria

### DIFF
--- a/blaze/model/a3c.py
+++ b/blaze/model/a3c.py
@@ -14,6 +14,7 @@ from .model import SavedModel
 WINDOW_SIZE = 50
 MAX_ITERATIONS = 250
 MIN_ITERATIONS = 50
+MAX_TIME_SECONDS = 2 * 60 * 60  # 2 hours
 
 
 def stop_condition():
@@ -29,8 +30,11 @@ def stop_condition():
 
     def stopper(trial_id, result):
         nonlocal num_iters, past_rewards
-
         num_iters += 1
+
+        if "time_since_restore" in result and result["time_since_restore"] >= MAX_TIME_SECONDS:
+            return True
+
         if "episode_reward_max" in result and "episode_reward_min" in result and "episode_reward_mean" in result:
             rewards = (result["episode_reward_min"], result["episode_reward_mean"], result["episode_reward_max"])
             log.debug("recording trial result", trial_id=trial_id, num_iters=num_iters, rewards=rewards)

--- a/blaze/model/a3c.py
+++ b/blaze/model/a3c.py
@@ -33,6 +33,7 @@ def stop_condition():
         num_iters += 1
 
         if "time_since_restore" in result and result["time_since_restore"] >= MAX_TIME_SECONDS:
+            log.info("auto stopping", time_seconds=result["time_since_restore"], iters=num_iters)
             return True
 
         if "episode_reward_max" in result and "episode_reward_min" in result and "episode_reward_mean" in result:
@@ -50,10 +51,10 @@ def stop_condition():
         if num_iters > MIN_ITERATIONS:
             stdev_min, stdev_mean, stdev_max = tuple(map(stdev, zip(*past_rewards)))
             log.debug("reward stats", stdev_min=stdev_min, stdev_mean=stdev_mean, stdev_max=stdev_max)
-            relative_stdev_based_stop = stdev_mean <= 0.05 * abs(past_rewards[-1][1])
+            relative_stdev_based_stop = stdev_mean <= 0.075 * abs(past_rewards[-1][1])
 
             if num_iters > MAX_ITERATIONS or relative_stdev_based_stop:
-                log.info("auto stopping", iters=num_iters)
+                log.info("auto stopping", time_seconds=result.get("time_since_restore", 0), iters=num_iters)
                 return True
 
         return False

--- a/tests/model/test_a3c.py
+++ b/tests/model/test_a3c.py
@@ -51,6 +51,11 @@ class TestStopCondition:
         assert not sc(0, {})
         assert not sc(0, {"episode_reward_mean": 10})
 
+    def test_stops_after_max_time(self):
+        sc = a3c.stop_condition()
+        assert not sc(0, {"episode_reward_mean": 1, "episode_reward_min": 0, "episode_reward_max": 2})
+        assert sc(0, {"time_since_restore": a3c.MAX_TIME_SECONDS + 1})
+
     def test_call_records_episode_result(self):
         sc = a3c.stop_condition()
         assert not sc(0, {"episode_reward_mean": 1, "episode_reward_min": 0, "episode_reward_max": 2})


### PR DESCRIPTION
Stops regardless of reward and number of iterations if the total time training since last restore (which equals total time trained if not restored) exceeds 2 hours.