### PR TITLE
Cleanup page_load_time command

### DIFF
--- a/blaze/command/analyze.py
+++ b/blaze/command/analyze.py
@@ -79,7 +79,7 @@ def page_load_time(args):
                 config.env_config.request_url, client_env, config, args.user_data_dir
             )
             if policy:
-                plt, *_ = get_speed_index_in_replay_server(
+                plt, *_ = get_page_load_time_in_replay_server(
                     config.env_config.request_url, client_env, config, args.user_data_dir, policy
                 )
         else:

--- a/blaze/command/analyze.py
+++ b/blaze/command/analyze.py
@@ -78,16 +78,18 @@ def page_load_time(args):
             orig_plt, *_ = get_page_load_time_in_replay_server(
                 config.env_config.request_url, client_env, config, args.user_data_dir
             )
-            plt, *_ = get_speed_index_in_replay_server(
-                config.env_config.request_url, client_env, config, args.user_data_dir, policy
-            )
+            if policy:
+                plt, *_ = get_speed_index_in_replay_server(
+                    config.env_config.request_url, client_env, config, args.user_data_dir, policy
+                )
         else:
             orig_plt = get_speed_index_in_replay_server(
                 config.env_config.request_url, client_env, config, args.user_data_dir
             )
-            plt = get_speed_index_in_replay_server(
-                config.env_config.request_url, client_env, config, args.user_data_dir, policy
-            )
+            if policy:
+                plt = get_speed_index_in_replay_server(
+                    config.env_config.request_url, client_env, config, args.user_data_dir, policy
+                )
 
     log.debug("running simulator...")
     sim = Simulator(env_config)

--- a/blaze/command/analyze.py
+++ b/blaze/command/analyze.py
@@ -1,8 +1,6 @@
 """ Implements the commands for analyzing training progress """
 import json
-import os
 import sys
-import tempfile
 
 from blaze.action import Policy
 from blaze.config.client import get_client_environment_from_parameters, get_default_client_environment
@@ -10,17 +8,12 @@ from blaze.config.config import get_config
 from blaze.config.environment import EnvironmentConfig
 from blaze.evaluator.simulator import Simulator
 from blaze.logger import logger as log
-from blaze.preprocess.record import (
-    record_webpage,
-    get_page_load_time_in_replay_server,
-    get_speed_index_in_replay_server,
-)
+from blaze.preprocess.record import get_page_load_time_in_replay_server, get_speed_index_in_replay_server
 
 from . import command
 
 
-@command.argument("url", nargs="?", help="The URL to analyze the page load time for")
-@command.argument("--from_manifest", help="The training manifest file to use as input to the simulator")
+@command.argument("--from_manifest", help="The training manifest file to use as input to the simulator", required=True)
 @command.argument(
     "--only_simulator",
     action="store_true",
@@ -41,11 +34,6 @@ from . import command
     help="Returns the speed index of the page calculated using pwmetrics. As a float.",
     action="store_true",
 )
-@command.argument(
-    "--extract_critical_requests",
-    help="Returns the response taking into account the critical resources in the page",
-    action="store_true",
-)
 @command.command
 def page_load_time(args):
     """
@@ -54,14 +42,6 @@ def page_load_time(args):
     the page in the same Mahimahi shell.
     """
     # Validate the arguments
-    if args.from_manifest and args.url:
-        log.warn("ignoring url since manifest was specified")
-    if not args.url and not args.from_manifest:
-        log.critical("either --from_manifest or a URL must be specified")
-        sys.exit(1)
-    if args.only_simulator and not args.from_manifest:
-        log.critical("--from_manifest must be specified to use with --only_simulator")
-        sys.exit(1)
     if args.latency is not None and args.latency < 0:
         log.critical("provided latency must be greater or equal to 0")
         sys.exit(1)
@@ -72,6 +52,7 @@ def page_load_time(args):
         log.critical("provided cpu slodown must be 1, 2, or 4")
         sys.exit(1)
 
+    # Setup the client environment
     default_client_env = get_default_client_environment()
     client_env = get_client_environment_from_parameters(
         args.bandwidth or default_client_env.bandwidth,
@@ -79,7 +60,7 @@ def page_load_time(args):
         args.cpu_slowdown or default_client_env.cpu_slowdown,
     )
 
-    plt = 0
+    # If a push/preload policy was specified, read it
     policy = None
     if args.policy:
         log.debug("reading policy", push_policy=args.policy)
@@ -87,64 +68,41 @@ def page_load_time(args):
             policy_dict = json.load(policy_file)
         policy = Policy.from_dict(policy_dict)
 
-    if args.from_manifest:
-        env_config = EnvironmentConfig.load_file(args.from_manifest)
-        config = get_config(env_config)
-        log.info("calculating page load time", manifest=args.from_manifest, url=env_config.request_url)
-        if not args.only_simulator:
-            log.debug("using pre-recorded webpage", record_dir=config.env_config.replay_dir)
-            if not args.speed_index:
-                plt, *_ = get_page_load_time_in_replay_server(
-                    config.env_config.request_url,
-                    client_env,
-                    config,
-                    args.user_data_dir,
-                    policy,
-                    args.extract_critical_requests,
-                )
-            else:
-                plt = get_speed_index_in_replay_server(
-                    config.env_config.request_url,
-                    client_env,
-                    config,
-                    args.user_data_dir,
-                    policy,
-                    args.extract_critical_requests,
-                )
+    env_config = EnvironmentConfig.load_file(args.from_manifest)
+    config = get_config(env_config)
 
-    else:
-        log.info("calculating page load time", url=args.url)
-        with tempfile.TemporaryDirectory() as record_dir:
-            # this is to work around the fact that mahimahi needs an empty directory
-            # so we use TemporaryDirectory to get a unique name for a directory and
-            # then delete it. After mahimahi runs and create the dir, then TemporaryDirectory
-            # can delete it as normal
-            os.rmdir(record_dir)
-            config = get_config(EnvironmentConfig(replay_dir=record_dir, request_url=args.url))
-            log.debug("recording webpage in Mahimahi", record_dir=record_dir)
-            record_webpage(args.url, record_dir, config)
-            log.debug("capturing median PLT in mahimahi with given environment")
-            plt, res_list, push_groups, _ = get_page_load_time_in_replay_server(
+    log.info("calculating page load time", manifest=args.from_manifest, url=env_config.request_url)
+    plt, orig_plt = 0, 0
+    if not args.only_simulator:
+        if not args.speed_index:
+            orig_plt, *_ = get_page_load_time_in_replay_server(
+                config.env_config.request_url, client_env, config, args.user_data_dir
+            )
+            plt, *_ = get_speed_index_in_replay_server(
                 config.env_config.request_url, client_env, config, args.user_data_dir, policy
             )
-
-            # If the user passed in a custom environment, we want to use the PLT from that environment
-            # but we want to use the HAR from the default page load to run in the simulator. This is to
-            # allow the simulator to simulate the custom environment on top of the default environment
-            # and to prevent conflating environments
-            if args.bandwidth or args.latency or args.cpu_slowdown:
-                log.debug("capturing median HAR in mahimahi for simulator in default environment")
-                _, res_list, push_groups, _ = get_page_load_time_in_replay_server(
-                    config.env_config.request_url, default_client_env, config, args.user_data_dir
-                )
-            env_config = EnvironmentConfig(
-                replay_dir=record_dir, request_url=args.url, push_groups=push_groups, har_resources=res_list
+        else:
+            orig_plt = get_speed_index_in_replay_server(
+                config.env_config.request_url, client_env, config, args.user_data_dir
+            )
+            plt = get_speed_index_in_replay_server(
+                config.env_config.request_url, client_env, config, args.user_data_dir, policy
             )
 
     log.debug("running simulator...")
     sim = Simulator(env_config)
+    orig_sim_plt = sim.simulate_load_time(client_env)
     sim_plt = sim.simulate_load_time(client_env, policy)
 
-    if not args.only_simulator:
-        log.info("real page load time", page_load_time=plt)
-    log.info("simulated page load time", page_load_time=sim_plt)
+    print(
+        json.dumps(
+            {
+                "client_env": client_env._asdict(),
+                "metric": "speed_index" if args.speed_index else "plt",
+                "cache": "warm" if args.user_data_dir else "cold",
+                "replay_server": {"with_policy": plt, "without_policy": orig_plt},
+                "simulator": {"with_policy": sim_plt, "without_policy": orig_sim_plt},
+            },
+            indent=4,
+        )
+    )

--- a/blaze/mahimahi/mahimahi.py
+++ b/blaze/mahimahi/mahimahi.py
@@ -23,24 +23,27 @@ class MahiMahiConfig:
     def har_capture_cmd(
         self,
         *,
+        capture_url: str,
         share_dir: str,
         har_output_file_name: str,
         policy_file_name: Optional[str] = None,
         link_trace_file_name: str = "",
-        capture_url: str,
         user_data_dir: Optional[str] = None,
-        extract_critical_requests: bool = False,
+        extract_critical_requests: Optional[bool] = False,
     ) -> List[str]:
         """
         Returns the full command to run that replays the configured folder with the given
         push policy and link trace name and stores output in the given output locations.
 
+        :param capture_url: The url to capture HAR for
         :param share_dir: the directory to share to the container
         :param har_output_file_name: the file inside share_dir to write the HAR output to
         :param policy_file_name: the file inside share_dir to read the push/preload policy from (JSON formatted)
         :param link_trace_file_name: the file inside share_dir to read the link trace from (Mahimahi formatted). If not
                                      specified, no mm-link shell will be spawned.
-        :param capture_url: The url to capture HAR for
+        :param user_data_dir: Indicates the the HAR capturer should use the given user data
+                              directory (warm cache load)
+        :param extract_critical_requests: The HAR capturer should extract critical requests
         """
         return [
             "docker",
@@ -51,8 +54,7 @@ class MahiMahiConfig:
             f"{self.config.env_config.replay_dir}:/mnt/filestore",
             "-v",
             f"{share_dir}:/mnt/share",
-            "-v",
-            *([f"{user_data_dir}:/mnt/chrome-user-dir"] if user_data_dir else []),
+            *(["-v", f"{user_data_dir}:/mnt/chrome-user-dir"] if user_data_dir else []),
             self.config.http2push_image,
             "--file-store-path",
             "/mnt/filestore",
@@ -82,13 +84,6 @@ class MahiMahiConfig:
         """
         Returns the full command to run that replays the configured folder with the given
         push policy and link trace name and stores speed index output in the given output locations.
-
-        :param share_dir: the directory to share to the container
-        :param har_output_file_name: the file inside share_dir to write the HAR output to
-        :param policy_file_name: the file inside share_dir to read the push/preload policy from (JSON formatted)
-        :param link_trace_file_name: the file inside share_dir to read the link trace from (Mahimahi formatted). If not
-                                     specified, no mm-link shell will be spawned.
-        :param capture_url: The url to capture HAR for
         """
         har_cmd = self.har_capture_cmd(
             share_dir=share_dir,

--- a/blaze/preprocess/record.py
+++ b/blaze/preprocess/record.py
@@ -21,7 +21,6 @@ from blaze.mahimahi import MahiMahiConfig
 from blaze.util.seq import ordered_uniq
 
 from .har import har_entries_to_resources, compute_parent_child_relationships
-from .resource import resource_list_to_push_groups
 from .url import Url
 
 EXECUTION_CAPTURE_RUNS = 5
@@ -161,11 +160,10 @@ def get_page_load_time_in_replay_server(
 
     hars.sort(key=lambda h: h.page_load_time_ms)
     plt_ms = [h.page_load_time_ms for h in hars]
-    log.debug("recorded execution times", plt_ms=plt_ms)
     median_har = hars[len(hars) // 2]
-    har_res_list = har_entries_to_resources(median_har)
-    har_push_groups = resource_list_to_push_groups(har_res_list)
-    return median_har.page_load_time_ms, har_res_list, har_push_groups, plt_ms
+    log.debug("recorded execution times", plt_ms=plt_ms)
+
+    return median_har.page_load_time_ms, plt_ms
 
 
 def get_speed_index_in_replay_server(


### PR DESCRIPTION
- Cleans up the `page_load_time` command by removing the option to record a website before analyzing it (instead, now it requires a pre-recorded and preprocessed dir)
- Output in JSON format like the `test_push` command
- Clean up the `get_page_load_time_in_replay_server` function